### PR TITLE
fix: 5 production-critical bugs discovered in real-world MCP tooling

### DIFF
--- a/src/aggregator/services.ts
+++ b/src/aggregator/services.ts
@@ -9,6 +9,39 @@ import { createTransport } from '../common/libs.js'
 
 const DEFAULT_MAX_PARALLEL_CALLS = 10
 
+/**
+ * Defensive parser for stringified JSON values in params.
+ * Some MCP clients (like Kai) may stringify arrays/objects in the JSON-RPC request.
+ * This recursively walks params and parses any stringified JSON.
+ */
+const parseStringifiedParams = (value: unknown): unknown => {
+  // If it's a string, try to parse it as JSON
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      // Recursively parse the result (in case of nested stringification)
+      return parseStringifiedParams(parsed)
+    } catch {
+      // Not valid JSON, return as-is
+      return value
+    }
+  }
+  // If it's an array, recursively parse each element
+  if (Array.isArray(value)) {
+    return value.map(parseStringifiedParams)
+  }
+  // If it's an object, recursively parse each value
+  if (value !== null && typeof value === 'object') {
+    return Object.entries(value).reduce((acc, [key, val]) => {
+      // eslint-disable-next-line functional/immutable-data
+      acc[key] = parseStringifiedParams(val)
+      return acc
+    }, {} as Record<string, unknown>)
+  }
+  // Primitive value, return as-is
+  return value
+}
+
 const create = (config: McpAggregatorConfig) => {
   // eslint-disable-next-line functional/no-let
   let clients: Record<string, Client> = {}
@@ -48,9 +81,12 @@ const create = (config: McpAggregatorConfig) => {
       return allTools.flat()
     },
     executeTool: async (toolName: string, params: any) => {
+      // Parse any stringified JSON in params (defensive fix for Kai stringification bug)
+      const parsedParams = parseStringifiedParams(params)
+      
       const client = toolToClient[toolName]
       return client
-        .callTool({ name: toolName, arguments: params })
+        .callTool({ name: toolName, arguments: parsedParams as Record<string, unknown> | undefined })
         .catch(() => [])
     },
   }

--- a/src/common/libs.ts
+++ b/src/common/libs.ts
@@ -56,6 +56,28 @@ export const createTransport = (connection: Connection) => {
   )
 }
 
+/**
+ * Defensive preprocessor for Zod schemas.
+ * Some MCP clients (like Kai) stringify arrays in JSON-RPC requests.
+ * This creates a pre-processor that attempts to parse stringified JSON before validation.
+ */
+const createStringifiedPreprocessor = (innerType: ZodType): ZodType => {
+  return z.preprocess(
+    (val) => {
+      // If it's a string, try to parse it as JSON
+      if (typeof val === 'string') {
+        try {
+          return JSON.parse(val)
+        } catch {
+          return val // Return as-is if not valid JSON
+        }
+      }
+      return val // Return as-is if not a string
+    },
+    innerType
+  ) as unknown as ZodType
+}
+
 export const openApiToZodSchema = (
   parameters: any
 ): Record<string, ZodType> => {
@@ -170,10 +192,16 @@ const createZodTypeFromDefinition = (def: any): ZodType => {
         const enumType = createEnumOrLiterals(enumValues, 'boolean')
         return enumType ?? z.boolean()
       }
-      case 'array':
-        return z.array(items ? createZodTypeFromDefinition(items) : z.any())
-      case 'object':
-        return z.object(openApiToZodSchema(def)).passthrough()
+      case 'array': {
+        // Wrap arrays with stringified JSON preprocessor to handle Kai's serialization
+        const innerArray = z.array(items ? createZodTypeFromDefinition(items) : z.any())
+        return createStringifiedPreprocessor(innerArray)
+      }
+      case 'object': {
+        // Wrap objects with stringified JSON preprocessor to handle Kai's serialization
+        const innerObject = z.object(openApiToZodSchema(def)).passthrough()
+        return createStringifiedPreprocessor(innerObject)
+      }
       default: {
         const enumType = createEnumOrLiterals(enumValues, null)
         return enumType ?? z.any()

--- a/src/common/libs.ts
+++ b/src/common/libs.ts
@@ -215,6 +215,34 @@ const createZodTypeFromDefinition = (def: any): ZodType => {
   return zodType
 }
 
+/**
+ * Check if value is a Zod schema using instanceof.
+ */
 export const isZodSchema = (schema: any): schema is ZodSchema => {
   return schema instanceof ZodSchema
+}
+
+/**
+ * Check if value is a raw shape (plain object with Zod validators).
+ * Raw shapes don't have _def/_zod but their values do.
+ */
+const isZodTypeLike = (value: any): boolean => {
+  return value && 
+    typeof value === 'object' && 
+    typeof value.parse === 'function' &&
+    typeof value.safeParse === 'function'
+}
+
+export const isZodRawShape = (schema: any): boolean => {
+  if (!schema || typeof schema !== 'object') return false
+  if (schema instanceof ZodSchema) return false  // Already a schema
+  const values = Object.values(schema)
+  return values.length > 0 && values.every(isZodTypeLike)
+}
+
+/**
+ * Wrap a raw shape into a Zod object schema.
+ */
+export const wrapRawShape = (shape: any): ZodSchema => {
+  return z.object(shape)
 }

--- a/src/integrator/services.ts
+++ b/src/integrator/services.ts
@@ -29,13 +29,14 @@ const createExecuteToolCalls =
     asyncMap(
       calls,
       async call => {
+        // Extract arguments, handling both wrapped and unwrapped formats
+        const input = call.input as { arguments?: unknown } | undefined
+        const args = input?.arguments ?? call.input
+
         const result = await client
           .callTool({
-            id: call.id,
             name: call.name,
-            // @ts-ignore I have absolutely seen the requirement to have this.
-            arguments: call.input,
-            input: call.input,
+            arguments: args as Record<string, unknown> | undefined,
           })
           .catch(e => {
             console.error(e)

--- a/src/simple-server/entries/cli.ts
+++ b/src/simple-server/entries/cli.ts
@@ -10,7 +10,6 @@ const create = (config: SimpleServerCliConfig) => {
     const server = new McpServer({
       name: config.name,
       version: config.version,
-      capabilities: { tools: config.tools },
     })
 
     const formatted = features.getFormattedTools()

--- a/src/simple-server/entries/http.ts
+++ b/src/simple-server/entries/http.ts
@@ -109,7 +109,7 @@ const create = (config: SimpleServerHttpConfig, options?: ExpressOptions) => {
     await transport.handleRequest(req, res)
   }
 
-  const _routeWrapper = async (
+  const _routeWrapper = (
     func: (req: express.Request, res: express.Response) => Promise<void> | void
   ) => {
     if (options?.afterRouteCallback) {

--- a/src/simple-server/entries/sse.ts
+++ b/src/simple-server/entries/sse.ts
@@ -93,7 +93,7 @@ const create = (config: SimpleServerSseConfig, options?: ExpressOptions) => {
     })
   }
 
-  const _routeWrapper = async (
+  const _routeWrapper = (
     func: (req: express.Request, res: express.Response) => Promise<void> | void
   ) => {
     if (options?.afterRouteCallback) {

--- a/src/simple-server/features.ts
+++ b/src/simple-server/features.ts
@@ -1,7 +1,12 @@
 import { isZodSchema, openApiToZodSchema } from '../common/libs.js'
 import { SimpleServerConfig } from './types.js'
 
-export const create = (config: SimpleServerConfig) => {
+interface Features {
+  getFormattedTools: () => any[]
+  validateConfig: () => void
+}
+
+export const create = (config: SimpleServerConfig): Features => {
   const tools = config.tools
 
   const getFormattedTools = () => {

--- a/src/simple-server/features.ts
+++ b/src/simple-server/features.ts
@@ -1,4 +1,4 @@
-import { isZodSchema, openApiToZodSchema } from '../common/libs.js'
+import { isZodSchema, isZodRawShape, wrapRawShape, openApiToZodSchema } from '../common/libs.js'
 import { SimpleServerConfig } from './types.js'
 
 interface Features {
@@ -10,27 +10,55 @@ export const create = (config: SimpleServerConfig): Features => {
   const tools = config.tools
 
   const getFormattedTools = () => {
-    return tools.map(tool => [
-      tool.name,
-      tool.description || '',
-      isZodSchema(tool.inputSchema)
-        ? tool.inputSchema
-        : openApiToZodSchema(tool.inputSchema),
-      async (input: any) => {
-        const result = await tool.execute(input)
-        if (result === undefined) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify(null),
-              },
-            ],
+    return tools.map(tool => {
+      // For raw shapes, pass them through directly - the SDK will wrap with z.object()
+      // This avoids cross-package Zod instance issues
+      if (isZodRawShape(tool.inputSchema)) {
+        return [
+          tool.name,
+          tool.description || '',
+          tool.inputSchema,  // Pass raw shape directly
+          async (input: any) => {
+            const result = await tool.execute(input)
+            if (result === undefined) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: JSON.stringify(null),
+                  },
+                ],
+              }
+            }
+            return result
+          },
+        ]
+      }
+
+      // For Zod schemas (same instance), use directly
+      // For OpenAPI, convert to Zod shape
+      return [
+        tool.name,
+        tool.description || '',
+        isZodSchema(tool.inputSchema)
+          ? tool.inputSchema
+          : openApiToZodSchema(tool.inputSchema),
+        async (input: any) => {
+          const result = await tool.execute(input)
+          if (result === undefined) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(null),
+                },
+              ],
+            }
           }
-        }
-        return result
-      },
-    ])
+          return result
+        },
+      ]
+    })
   }
 
   const validateConfig = () => {


### PR DESCRIPTION
## Summary

This PR addresses **5 production-critical bugs** discovered while building production MCP tooling at [Third Steeping](https://github.com/guan-tends). All fixes are backward-compatible and improve cross-client reliability.

### Bug Fixes

| Commit | Fix | Impact |
|--------|-----|--------|
|  | **Express handler regression** | Broke all HTTP/SSE transports — Express rejects non-function handlers |
|  | **Stringified JSON arrays in Zod**: Some MCP clients (e.g., Kai) stringify arrays/objects in JSON-RPC requests before sending | Array-param tools (pty-bash, batch_generate) fail with validation errors |
|  | **Double-wrapped arguments handled**  | Array parameters corrupted with protocol errors |
|  | **SDK v1.29.0 compatibility**:  constructor no longer accepts  | Build breaks on SDK v1.29.0+ |
|  | **Cross-package Zod schema detection**:  fails across npm package boundaries | Server crash when tools define schemas using a different Zod instance |

### Testing

All fixes have been validated against:
- Multiple MCP client implementations (Kai, custom aggregators)
- SDK versions 1.28.x through 1.30.x
- Express 4.x HTTP and SSE transports
- Cross-package npm installs (Zod from different dependency trees)

### Co-Authors

- **Guan** (@guan-tends) — discovery, implementation, testing
- Original library: **Mike Cornwell** (@Leadership-4-Tech)

### License

All changes remain under the existing GPL-3.0-or-later license.

---

*These fixes were discovered and hardened while building [passgen](https://github.com/guan-tends/passgen), a deterministic passphrase generator with MCP tooling integration. Our environment exercises the edge cases that break in real-world production.*